### PR TITLE
Fix typos in CI and DVCS slides

### DIFF
--- a/ci/intro.md
+++ b/ci/intro.md
@@ -51,7 +51,7 @@ Traditionally, **protoduction** is jargon for a *prototype that ends up in produ
         * *unpolished*,
         * *badly designed*
     * Very common, unfortunately
-* This si different in a continuously integrated environment
+* This is different in a continuously integrated environment
     * *Incrementality* is fostered
     * Partial features are *up to date* with the mainline
 </div>

--- a/git/dvcs-concepts.md
+++ b/git/dvcs-concepts.md
@@ -61,7 +61,7 @@ developers work on a subset of such history
 
 * **Concurrent Versioning System (CVS)** (1986): client-server (*centralized* model, the truth is on the server), operates on single files or repository-level, history stored in a hidden directory, uses delta compression to save space.
 * **Apache Subversion (SVN)** (2000): successor to CVS, still largely used (especially in businesses that struggle to renovate their processes). *Centralized* model (similar to CVS). Improved binary file management. Improved concurrency for the operation, still cumbersome for parallel workflows.
-* **Mercurial** and **Git** (both April 2005): *decentralized* version control systems (DVCSs), no "special" copy of the repository, each client stores the whole history. Highly scalable. Foster parallel work by allowing easy branching and merging. Very similar conceptually (when two succesful tools emerge at the same time with a similar model independently, it is an indication that the underlying model is "the right one" for the context).
+* **Mercurial** and **Git** (both April 2005): *decentralized* version control systems (DVCSs), no "special" copy of the repository, each client stores the whole history. Highly scalable. Foster parallel work by allowing easy branching and merging. Very similar conceptually (when two successful tools emerge at the same time with a similar model independently, it is an indication that the underlying model is "the right one" for the context).
 
 **Git** is now the dominant DVCS (although Mercurial is still in use, e.g., for Python, Java, Facebook).
 


### PR DESCRIPTION
### Motivation
- Fix small spelling mistakes in slide content to improve clarity and correctness.

### Description
- Corrected `This si` → `This is` in `ci/intro.md`.
- Corrected `succesful` → `successful` in `git/dvcs-concepts.md`.

### Testing
- Ran `rg -n "\b(succesful|This si)\b" || true` across the repository and confirmed no matches for the corrected typo patterns.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69df99a47158833581b9fab92b5dd698)